### PR TITLE
Add reset method to EoWriter and fix comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: Check format with Prettier
         uses: creyD/prettier_action@v4.3

--- a/src/data/eo-writer.ts
+++ b/src/data/eo-writer.ts
@@ -157,7 +157,7 @@ export class EoWriter {
    * <p>With string sanitization enabled, the writer will switch `0xFF` bytes in strings (ÿ)
    * to `0x79` (y).
    *
-   * @param chunkedReadingMode - the new chunked reading mode
+   * @param stringSanitizationMode - the new string sanitization mode
    */
   public set stringSanitizationMode(stringSanitizationMode: boolean) {
     this._stringSanitizationMode = stringSanitizationMode;


### PR DESCRIPTION
Felt this would have been useful during development when I wanted to re-use a writer rather than setting it to a new instance.